### PR TITLE
chore: sync Cargo manifest/lock to 1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "dslf"
-version = "1.2.1"
+version = "1.3.1"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dslf"
-version = "1.2.1"
+version = "1.3.1"
 edition = "2024"
 description = "Damn Small Link Forwarder: a tiny self-hosted link shortener and forwarder."
 repository = "https://github.com/vpetersson/dslf"


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml` from `1.2.1` → `1.3.1` and refreshes `Cargo.lock` to match
- Catches the manifest up to the already-tagged `v1.3.0`/`v1.3.1` releases, which were cut without bumping the crate version
- `bun install` produced no changes — `bun.lock` was already in sync

## Test plan
- [ ] `cargo build` succeeds
- [ ] `cargo test` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)