### PR TITLE
chore: bump to 1.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "dslf"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dslf"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2024"
 description = "Damn Small Link Forwarder: a tiny self-hosted link shortener and forwarder."
 repository = "https://github.com/vpetersson/dslf"


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml` `1.3.1` → `1.3.2` and refreshes `Cargo.lock`
- Prep commit for cutting the `v1.3.2` tag once this merges

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)